### PR TITLE
8 bits binary counter example for the Icezum Alhambra board

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
 *.d
 .gdb_history
+*.bin
+*.asc
+*.blif
+*.cf
+*.rpt
+*.o
+*.so
+

--- a/icezum/counter-8bits/Makefile
+++ b/icezum/counter-8bits/Makefile
@@ -1,0 +1,32 @@
+PROJ = counter8
+PIN_DEF = counter8.pcf
+DEVICE = hx1k
+
+all: $(PROJ).rpt $(PROJ).bin
+
+%.blif: %.vhdl
+	ghdl -a $(PROJ).vhdl
+	yosys -m ../../ghdl.so -p 'ghdl $(PROJ); synth_ice40 -blif $@'
+
+
+%.asc: $(PIN_DEF) %.blif
+	arachne-pnr -d $(subst hx,,$(subst lp,,$(DEVICE))) -o $@ -p $^
+
+%.bin: %.asc
+	icepack $< $@
+
+%.rpt: %.asc
+	icetime -d $(DEVICE) -mtr $@ $<
+
+prog: $(PROJ).bin
+	iceprog $<
+
+sudo-prog: $(PROJ).bin
+	@echo 'Executing prog as root!!!'
+	sudo iceprog $<
+
+clean:
+	rm -f $(PROJ).blif $(PROJ).asc $(PROJ).rpt $(PROJ).bin work-obj93.cf
+
+.SECONDARY:
+.PHONY: all prog clean

--- a/icezum/counter-8bits/README.md
+++ b/icezum/counter-8bits/README.md
@@ -1,0 +1,16 @@
+A hello world example for the **Icezum Alhambra board**
+It just blinks all the leds
+
+Execute
+
+```sh
+$ make
+```
+
+for synthesizing the example and
+
+```sh
+$ make prog
+```
+
+for programing the board

--- a/icezum/counter-8bits/counter8.pcf
+++ b/icezum/counter-8bits/counter8.pcf
@@ -1,0 +1,9 @@
+set_io --warn-no-port led0  95   # output
+set_io --warn-no-port led1  96   # output
+set_io --warn-no-port led2  97   # output
+set_io --warn-no-port led3  98   # output
+set_io --warn-no-port led4  99   # output
+set_io --warn-no-port led5  101  # output
+set_io --warn-no-port led6  102  # output
+set_io --warn-no-port led7  104  # output
+set_io --warn-no-port clk 21

--- a/icezum/counter-8bits/counter8.vhdl
+++ b/icezum/counter-8bits/counter8.vhdl
@@ -1,0 +1,38 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity counter8 is
+  port (clk : in std_logic;
+        led0, led1, led2, led3, led4, led5, led6, led7 : out std_logic);
+end counter8;
+
+architecture synth of counter8 is
+
+  signal clk_6hz : std_logic;
+
+begin
+
+  -- Presscaler
+  prescaler: process(clk)
+    variable timer : unsigned (20 downto 0):=(others=>'0');
+  begin
+    if rising_edge(clk) then
+      timer := timer + 1;
+      clk_6hz <= timer(20);
+    end if;
+  end process;
+
+  -- 8 bits counter
+  process (clk_6hz)
+    variable temp : unsigned (7 downto 0);
+  begin
+    if rising_edge(clk_6hz) then
+      temp:= temp + 1;
+
+      -- Show the counter on the icezum Alhambra leds
+      (led7, led6, led5, led4, led3, led2, led1, led0) <= temp;
+    end if;
+  end process;
+
+end synth;


### PR DESCRIPTION
A binary counter is shown in the 8 leds of the Icezum Alhambra board
