### PR TITLE
Handle Id_Asr

### DIFF
--- a/src/ghdl.cc
+++ b/src/ghdl.cc
@@ -299,6 +299,7 @@ static void import_module(RTLIL::Design *design, GhdlSynth::Module m)
                 case Id_Red_And:
                 case Id_Lsr:
                 case Id_Lsl:
+                case Id_Asr:
                 case Id_Assert:  // No output
                 case Id_Assume:  // No output
                 case Id_Cover:  // No output
@@ -431,6 +432,9 @@ static void import_module(RTLIL::Design *design, GhdlSynth::Module m)
 			break;
 		case Id_Lsr:
 			module->addShr(to_str(iname), IN(0), IN(1), OUT(0));
+			break;
+		case Id_Asr:
+			module->addSshr(to_str(iname), IN(0), IN(1), OUT(0), true);
 			break;
 		case Id_Mux2:
 			module->addMux(to_str(iname), IN(1), IN(2), IN(0), OUT(0));


### PR DESCRIPTION
This PR adds handling of `Id_Asr` for supporting `shift_right(signed, nat)` of numeric_std.

I've tested the handling of the shift functions. The tests will follow later, as they rely on SymbiYosys to formally verify the results. Don't know how to integrate such tests here at the moment, maybe @1138-4EB could help.