### PR TITLE
Handle Id_Sextend

### DIFF
--- a/src/ghdl.cc
+++ b/src/ghdl.cc
@@ -75,6 +75,12 @@ static RTLIL::SigSpec get_src(std::vector<RTLIL::Wire *> &net_map, Net n)
 			res.extend_u0(get_width(n), false);
 			return res;
 		}
+	case Id_Sextend:
+		{
+			RTLIL::SigSpec res = IN(0);
+			res.extend_u0(get_width(n), true);
+			return res;
+		}
 	case Id_Utrunc:
 	case Id_Strunc:
 		{
@@ -325,6 +331,7 @@ static void import_module(RTLIL::Design *design, GhdlSynth::Module m)
 		case Id_Const_Z:
 		case Id_Const_X:
 		case Id_Uextend:
+		case Id_Sextend:
 		case Id_Utrunc:
 		case Id_Strunc:
 		case Id_Extract:
@@ -510,6 +517,7 @@ static void import_module(RTLIL::Design *design, GhdlSynth::Module m)
 		case Id_Const_Z:
 		case Id_Const_X:
 		case Id_Uextend:
+		case Id_Sextend:
 		case Id_Utrunc:
 		case Id_Strunc:
 		case Id_Extract:


### PR DESCRIPTION
Adds handling of `Id_Sextend`. It's similar handled as `Id_Uextend`, with the difference that the `is_signed` parameter of `RTLIL::SigSpec::extend_u0()` is set to `true`.

As `RTLIL::SigSpec::extend_u0()` is implemented in the following way, this should work:

```c++
void RTLIL::SigSpec::extend_u0(int width, bool is_signed)
{
	cover("kernel.rtlil.sigspec.extend_u0");

	pack();

	if (width_ > width)
		remove(width, width_ - width);

	if (width_ < width) {
		RTLIL::SigBit padding = width_ > 0 ? (*this)[width_ - 1] : RTLIL::State::Sx;
		if (!is_signed)
			padding = RTLIL::State::S0;
		while (width_ < width)
			append(padding);
	}

}
```


Tests follow later if I have a MWE.