### PR TITLE
Fix a couple of compiler warnings

### DIFF
--- a/src/ghdl.cc
+++ b/src/ghdl.cc
@@ -92,7 +92,7 @@ static RTLIL::SigSpec get_src(std::vector<RTLIL::Wire *> &net_map, Net n)
 		{
 		       const unsigned wd = get_width(n);
 		       std::vector<RTLIL::State> bits(wd);
-		       unsigned int val;
+		       unsigned int val = 0;
 		       for (unsigned i = 0; i < wd; i++) {
 			       if (i % 32 == 0)
 			               val = get_param_uns32(inst, i / 32);
@@ -113,8 +113,8 @@ static RTLIL::SigSpec get_src(std::vector<RTLIL::Wire *> &net_map, Net n)
 	        {
 		       const unsigned wd = get_width(n);
 		       std::vector<RTLIL::State> bits(wd);
-		       unsigned int val01;
-		       unsigned int valzx;
+		       unsigned int val01 = 0;
+		       unsigned int valzx = 0;
 		       for (unsigned i = 0; i < wd; i++) {
 			       if (i % 32 == 0) {
 			               val01 = get_param_uns32(inst, 2*(i / 32));


### PR DESCRIPTION
I see a few compiler warnings on gcc 9.2:

src/ghdl.cc: In function ‘Yosys::RTLIL::SigSpec get_src(std::vector<Yosys::RTLIL::Wire*>&, GhdlSynth::Net)’:
src/ghdl.cc:123:43: warning: ‘valzx’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  123 |           switch(((val01 >> i)&1)+((valzx >> i)&1)*2)
      |                                    ~~~~~~~^~~~~
src/ghdl.cc:123:26: warning: ‘val01’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  123 |           switch(((val01 >> i)&1)+((valzx >> i)&1)*2)
      |                   ~~~~~~~^~~~~
src/ghdl.cc:99:26: warning: ‘val’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   99 |           bits[i] = (val >> i) & 1 ? RTLIL::State::S1 : RTLIL::State::S0;
      |                     ~~~~~^~~~~

These both appear to be spurious, but initialize them to 0 to avoid the
warning.