### PR TITLE
Add abs gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 *.o
 *.so
 
+testsuite/**/work/

--- a/src/ghdl.cc
+++ b/src/ghdl.cc
@@ -557,6 +557,7 @@ static void import_module(RTLIL::Design *design, GhdlSynth::Module m)
 		case Id_Sgt:
 		case Id_Sge:
 		case Id_Not:
+		case Id_Abs:
 		case Id_Red_Or:
 		case Id_Red_And:
 		case Id_Lsr:
@@ -678,6 +679,14 @@ static void import_module(RTLIL::Design *design, GhdlSynth::Module m)
 			break;
 		case Id_Not:
 			module->addNot(to_str(iname), IN(0), OUT(0));
+			break;
+		case Id_Abs:
+			{
+				SigSpec isNegative = IN(0).extract(IN(0).size() - 1, 1);
+				RTLIL::Wire *negated = module->addWire(NEW_ID, IN(0).size());
+				module->addNeg(NEW_ID, IN(0), negated);
+				module->addMux(NEW_ID, IN(0), negated, isNegative, OUT(0));
+			}
 			break;
 		case Id_Eq:
 			module->addEq(to_str(iname), IN(0), IN(1), OUT(0));

--- a/testsuite/formal/abs/test_abs.sby
+++ b/testsuite/formal/abs/test_abs.sby
@@ -1,0 +1,13 @@
+[options]
+#depth 6
+mode prove
+
+[engines]
+smtbmc z3
+
+[script]
+ghdl --std=08 test_abs.vhd -e ent
+prep -top ent
+
+[files]
+test_abs.vhd

--- a/testsuite/formal/abs/test_abs.vhd
+++ b/testsuite/formal/abs/test_abs.vhd
@@ -1,0 +1,37 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity ent is
+	port (
+		clk : in std_logic;
+		a : in signed(7 downto 0);
+		b : out signed(7 downto 0)
+	);
+end;
+
+architecture a of ent is
+begin
+	process(clk)
+	begin
+		if rising_edge(clk) then
+			b <= abs a;
+		end if;
+	end process;
+
+	formal: block
+		signal last_a : signed(7 downto 0);
+		signal has_run : std_logic := '0';
+	begin
+		process(clk)
+		begin
+			if rising_edge(clk) then
+				has_run <= '1';
+				last_a <= a;
+			end if;
+		end process;
+
+		default clock is rising_edge(clk);
+		assert always has_run -> b >= 0 or (last_a = x"80" and last_a = b);
+	end block;
+end;

--- a/testsuite/formal/abs/testsuite.sh
+++ b/testsuite/formal/abs/testsuite.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+topdir=../..
+. $topdir/testenv.sh
+
+formal "test_abs"
+
+clean
+echo OK


### PR DESCRIPTION
yosys doesn't have a dedicated abs gate, so a negation+mux has to be used. I also added a formal test, so I'm reasonably certain it's correct - the extreme case of `abs(-127)` mirrors the `numeric_std` simulation code and returns the value unchanged.